### PR TITLE
Fix for horsepower results

### DIFF
--- a/EngineAnalyticsWebApp.UI/Components/Pages/Reports/HorsepowerResults.razor
+++ b/EngineAnalyticsWebApp.UI/Components/Pages/Reports/HorsepowerResults.razor
@@ -23,7 +23,7 @@
     </TableHeader>
     <RowTemplate Context="auto">
         <tr>
-            <td>@auto.Year ?? 0</td>
+            <td>@(auto.Year is > 0 ? auto.Year.ToString() : "")</td>
             <td>@auto.Make</td>
             <td>@auto.Model</td>
             @if (auto.EngineAnalytics != null)


### PR DESCRIPTION
This pull request makes a minor update to the display logic in the `HorsepowerResults.razor` report page. The change improves how the `Year` field is rendered in the table by showing an empty string instead of `0` when the year is not set.

* Improved table rendering: The `Year` column now displays an empty string when `auto.Year` is not greater than zero, instead of showing `0`.